### PR TITLE
Added a comma in db/schema.sql that prevented it from running

### DIFF
--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -54,8 +54,8 @@ CREATE TABLE rent_payments(
 );
 
 CREATE TABLE utility_information(
-    id SERIAL PRIMARY KEY
-    user_id INTEGER REFERENCES users(id) NOT NULL ,
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) NOT NULL,
     water_cost DECIMAL(10, 2),
     water_usage DECIMAL,
     electric_usage DECIMAL,


### PR DESCRIPTION
When I tried running `db/schema.sql`, it didn't work because one of the lines was missing a comma.