### PR TITLE
Removed 'NOT NULL' from unit field in users table

### DIFF
--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -28,7 +28,7 @@ CREATE TABLE users(
     first_name VARCHAR(50) NOT NULL,
     last_name VARCHAR(50) NOT NULL,
     email VARCHAR(255) NOT NULL,
-    unit INTEGER REFERENCES units(id) NOT NULL,
+    unit INTEGER REFERENCES units(id),
     is_manager BOOLEAN NOT NULL,
     is_current_user BOOLEAN NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP


### PR DESCRIPTION
Literally a one line change. In the users table, unit is no longer required as managers do not need to live in a unit.