### PR TITLE
fixed schems: removed auto completed_at timestamp

### DIFF
--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -76,7 +76,7 @@ CREATE TABLE maintenance_requests(
     user_id INTEGER REFERENCES users(id) NOT NULL,
     completed BOOLEAN NOT NULL DEFAULT false,
     unit_number INTEGER REFERENCES units(id) NOT NULL, 
-    completed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    completed_at TIMESTAMP
 );
 
 CREATE TABLE maintenance_photos (


### PR DESCRIPTION
@kai - This should fix the maintenance timestamp bug. Please test and merge when ready

Problem: 
- New maintenance requests were automatically getting a completed_at timestamp upon creation even when completed = false
Cause:
- schema had completed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP which set a timestamp for every new record
Solution:
- Removed the default so: new requests have completed_at = null, marking requests as completed still sets the timestamp
Testing:
- Kai - Please test and let me know if the solution resolves the issues you were having