### PR TITLE
Renamed packages in node package files

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "property_management_capstone",
+  "name": "property_management_capstone_backend",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "property_management_capstone",
+      "name": "property_management_capstone_backend",
       "dependencies": {
         "bcrypt": "^5.1.1",
         "cors": "^2.8.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "property_management_capstone",
+  "name": "property_management_capstone_backend",
   "type": "module",
   "imports": {
     "#*": "./*.js"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "foobar",
+  "name": "property_management_capstone_frontend",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "foobar",
+      "name": "property_management_capstone_frontend",
       "dependencies": {
         "axios": "^1.10.0",
         "react": "^19.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "foobar",
+  "name": "property_management_capstone_frontend",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
The package names in `package.json` and `package-lock.json` in both `/frontend` and `/backend` folders were renamed.